### PR TITLE
api/core Add modules for DynamoDB/Memory storage and Account entity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           target/
         key: cargo-linux-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: cargo-linux
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
     - run: ./run.sh deps
     - run: ./run.sh build
     - run: ./run.sh test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "api-core"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "aws-config",
+ "aws-sdk-dynamodb",
+ "futures",
+ "lazy_static",
+ "logic",
+ "rand",
+ "time",
+ "tokio",
+ "ulid",
+]
+
+[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,15 +118,338 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-config"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6befba9ce7b81b58b1249c854da754e2236dbee548a736b96230216ebf9bcadc"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5879bec6e74b648ce12f6085e7245417bc5f6d672781028384d2e494be3eb6d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef4cd9362f638c22a3b959fd8df292e7e47fdf170270f86246b97109b5f2f7d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e2735d2ab28b35ecbb5496c9d41857f52a0d6a0075bbf6a8af306045ea6f6"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "aws_lambda_events"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7319a086b79c3ff026a33a61e80f04fd3885fbb73237981ea080d21944e1cb1c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-serde",
  "query_map",
  "serde",
@@ -134,9 +473,25 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "basic-toml"
@@ -157,12 +512,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -210,6 +602,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +670,18 @@ checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fnv"
@@ -332,6 +797,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +843,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +878,32 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -379,12 +918,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -395,8 +945,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -406,7 +956,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
 dependencies = [
- "http",
+ "http 1.1.0",
  "serde",
 ]
 
@@ -417,6 +967,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,14 +1005,30 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -444,9 +1040,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -466,10 +1062,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lambda-health"
@@ -502,15 +1117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fe279be7f89f5f72c97c3a96f45c43db8edab1007320ecc6a5741273b4d6db"
 dependencies = [
  "aws_lambda_events",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.4.1",
  "lambda_runtime",
  "mime",
  "percent-encoding",
@@ -529,14 +1144,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed49669d6430292aead991e19bf13153135a884f916e68f32997c951af637ebe"
 dependencies = [
  "async-stream",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-serde",
- "hyper",
+ "hyper 1.4.1",
  "hyper-util",
  "lambda_runtime_api_client",
  "pin-project",
@@ -559,10 +1174,10 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.4.1",
  "hyper-util",
  "tokio",
  "tower",
@@ -673,6 +1288,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +1325,18 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "paste"
@@ -738,6 +1389,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +1430,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -799,6 +1495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,16 +1513,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "scroll"
@@ -843,6 +1621,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,18 +1664,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.205"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.205"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -873,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -906,12 +1717,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -952,10 +1783,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1008,6 +1851,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1906,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",
@@ -1050,12 +1924,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -1163,6 +2060,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ulid"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
+dependencies = [
+ "getrandom",
+ "rand",
+ "serde",
+ "web-time",
+]
 
 [[package]]
 name = "unicase"
@@ -1324,6 +2239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +2254,18 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"
@@ -1345,6 +2278,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"
@@ -1360,6 +2299,71 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "weedle2"
@@ -1442,3 +2446,36 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "api/lambda-health",
     "api/lambda-ws-connect",
     "api/lambda-ws-disconnect",
+    "api/core",
     "logic",
     "logic-binding-cpp",
     "logic-binding-wasm",

--- a/api/core/Cargo.toml
+++ b/api/core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "api-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-stream = "0.3.5"
+aws-config = { version = "1.5.5", features = ["behavior-version-latest"] }
+aws-sdk-dynamodb = "1.43.0"
+futures = "0.3.30"
+lazy_static = "1.5.0"
+logic = { path = "../../logic" }
+rand = "0.8.5"
+time = "0.3.36"
+tokio = { version = "1.39.3", features = ["macros"] }
+ulid = { version = "1.1.3", features = ["serde"] }

--- a/api/core/README.md
+++ b/api/core/README.md
@@ -1,0 +1,3 @@
+# api-core
+
+Contains shared structs and functionality which is used across all the API lambdas, such as DynamoDB storage and structs for stored entities.

--- a/api/core/src/entities.rs
+++ b/api/core/src/entities.rs
@@ -1,0 +1,87 @@
+use std::{collections::HashMap, str::FromStr};
+
+use aws_sdk_dynamodb::{
+    operation::put_item::builders::PutItemFluentBuilder, types::AttributeValue,
+};
+use time::OffsetDateTime;
+use ulid::Ulid;
+
+use crate::storage::{Entity, Key, StorageErr};
+
+// User identifier, randomly generated ULID
+#[derive(Debug, PartialEq, Clone)]
+pub struct UserId(Ulid);
+
+impl UserId {
+    // Creates new randomly generated user identifier
+    pub fn generate() -> Self {
+        Self(ulid::Ulid::new())
+    }
+
+    // Returns string representation of a user_id
+    pub fn as_str(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl FromStr for UserId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ulid::Ulid::from_string(s)
+            .map(UserId)
+            .map_err(|err| err.to_string())
+    }
+}
+
+// Player account
+#[derive(Debug, PartialEq)]
+pub struct Account {
+    pub key: Key,
+    pub created_at: i64,
+}
+
+impl Entity for Account {
+    fn entity_type() -> &'static str {
+        "account"
+    }
+
+    fn key(&self) -> &Key {
+        &self.key
+    }
+
+    fn serialize(&self, writer: PutItemFluentBuilder) -> PutItemFluentBuilder {
+        writer.item("created_at", AttributeValue::N(self.created_at.to_string()))
+    }
+
+    fn deserialize(key: Key, data: HashMap<String, AttributeValue>) -> Result<Self, StorageErr> {
+        let created_at = read_number_attribute(data, "created_at")?;
+        Ok(Self { key, created_at })
+    }
+}
+
+impl Account {
+    // Generate new account with random user_id
+    pub fn generate() -> Self {
+        let user_id = UserId::generate();
+        // For account entity id is the same as a user id
+        let entity_id = user_id.as_str().to_string();
+        Self {
+            created_at: OffsetDateTime::now_utc().unix_timestamp(),
+            key: Key { user_id, entity_id },
+        }
+    }
+}
+
+fn read_number_attribute<T: FromStr>(
+    attributes: HashMap<String, AttributeValue>,
+    key: &str,
+) -> Result<T, StorageErr> {
+    attributes
+        .get(key)
+        .ok_or_else(|| StorageErr::ValidationError(format!("{} attribute not found", key)))?
+        .as_n()
+        .map_err(|_| StorageErr::ValidationError(format!("{} is not a number attribute", key)))?
+        .parse()
+        .map_err(|_| StorageErr::ValidationError(format!("{} cannot be parsed as number", key)))
+}

--- a/api/core/src/lib.rs
+++ b/api/core/src/lib.rs
@@ -1,0 +1,6 @@
+#![allow(async_fn_in_trait)] // Ignore it as we plan to use async trait only in our code which is fine
+
+pub mod entities;
+pub mod storage;
+pub mod storage_dynamodb;
+pub mod storage_memory;

--- a/api/core/src/storage.rs
+++ b/api/core/src/storage.rs
@@ -182,7 +182,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dynamodb_storage() {
-        if std::env::var("AWS_PROFILE").is_err() && std::env::var("AWS_ACCESS_KEY_ID=").is_err() {
+        if std::env::var("AWS_PROFILE").is_err() && std::env::var("CI").is_err() {
             println!("No AWS credentials set, skipping DynamoDB test");
             return;
         }

--- a/api/core/src/storage.rs
+++ b/api/core/src/storage.rs
@@ -1,0 +1,194 @@
+use std::{collections::HashMap, pin::Pin};
+
+use aws_sdk_dynamodb::{
+    operation::put_item::builders::PutItemFluentBuilder, types::AttributeValue,
+};
+use futures::Stream;
+
+use crate::entities::UserId;
+
+// Storage error types
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
+pub enum StorageErr {
+    ValidationError(String),
+    IOError(String),
+    NotFound,
+}
+
+// Base user entity where partition key is user id
+pub trait Entity {
+    // Return entity type name which is used as a static prefix for the sort key
+    fn entity_type() -> &'static str;
+
+    // Return entity key
+    fn key(&self) -> &Key;
+
+    // Serialize entity data to the writer for storing it in the database
+    fn serialize(&self, writer: PutItemFluentBuilder) -> PutItemFluentBuilder;
+
+    // Deserialize an entity from the data read from the database
+    fn deserialize(key: Key, data: HashMap<String, AttributeValue>) -> Result<Self, StorageErr>
+    where
+        Self: Sized;
+}
+
+// Entity key - user_id as partition key and entity_id as a sort key
+#[derive(Debug, PartialEq, Clone)]
+pub struct Key {
+    pub user_id: UserId,
+    pub entity_id: String,
+}
+
+// Base trait for the storage provider
+pub trait Storage {
+    // Creates a new Storage for the given table name
+    async fn new(table: &'static str) -> Self;
+
+    // Store user entity in the database
+    async fn write<T: Entity>(&self, entity: &T) -> Result<(), StorageErr>;
+
+    // Read user entity from the database
+    async fn read<T>(&self, key: Key) -> Result<T, StorageErr>
+    where
+        T: Entity;
+
+    // Find all the entities for the given partition key and entity type, output is streamed
+    async fn find<T>(&self, user_id: &UserId) -> Pin<Box<dyn Stream<Item = Result<T, StorageErr>>>>
+    where
+        T: Entity + 'static;
+
+    // Delete entities in the give partition with optional entity type and sort key
+    async fn delete(
+        &self,
+        user_id: &UserId,
+        entity_type: Option<&str>,
+        entity_id: Option<&str>,
+    ) -> Result<usize, StorageErr>;
+
+    // Delete all the entries for the giver user id
+    async fn delete_user_data(&self, user_id: &UserId) -> Result<usize, StorageErr> {
+        self.delete(user_id, None, None).await
+    }
+
+    // Delete all the entries of the given type for the given user
+    async fn delete_entities(
+        &self,
+        user_id: &UserId,
+        entity_type: &str,
+    ) -> Result<usize, StorageErr> {
+        self.delete(user_id, Some(entity_type), None).await
+    }
+
+    // Delete an entity
+    async fn delete_entity<T>(&self, entity: T) -> Result<usize, StorageErr>
+    where
+        T: Entity,
+    {
+        self.delete(
+            &entity.key().user_id,
+            Some(T::entity_type()),
+            Some(&entity.key().entity_id),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use lazy_static::lazy_static;
+    use time::OffsetDateTime;
+
+    use crate::{
+        entities::{Account, UserId},
+        storage_dynamodb::DynamoStorage,
+        storage_memory::MemoryStorage,
+    };
+
+    use super::*;
+
+    lazy_static! {
+        static ref User1: UserId = "01D39ZY06FGSCTVN4T2V9PKHFZ".parse().unwrap();
+        static ref User2: UserId = "2D9RW50MA499CMAGHM6DD42DTP".parse().unwrap();
+    }
+
+    const TABLE: &str = "game_data_test";
+
+    fn random_account(user: &UserId) -> Account {
+        Account {
+            key: Key {
+                user_id: user.clone(),
+                entity_id: Account::entity_type().to_string(),
+            },
+            created_at: OffsetDateTime::now_utc().unix_timestamp(),
+        }
+    }
+
+    async fn test_storage(storage: &impl Storage) {
+        // Read/Write/Overwrite
+        let acc_orig = random_account(&User1);
+        storage.write(&acc_orig).await.unwrap();
+        let mut acc_read = storage.read(acc_orig.key.clone()).await.unwrap();
+        assert_eq!(acc_orig, acc_read);
+        acc_read.created_at += 1;
+        storage.write(&acc_read).await.unwrap();
+        let acc_modified = storage.read(acc_read.key.clone()).await.unwrap();
+        assert_ne!(acc_orig, acc_modified);
+        assert_eq!(acc_modified.created_at, acc_read.created_at);
+
+        // Delete/Read
+        let key = acc_orig.key.clone();
+        storage.delete_entity(acc_orig).await.unwrap();
+        assert!(matches!(
+            storage.read::<Account>(key).await,
+            Err(StorageErr::NotFound)
+        ));
+
+        // Find
+        let acc = random_account(&User1);
+        storage.write(&acc).await.unwrap();
+        let found = storage
+            .find::<Account>(&User1)
+            .await
+            .map(|v| v.unwrap())
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(found, vec![acc]);
+        assert!(storage.find::<Account>(&User2).await.next().await.is_none());
+
+        // Delete entities
+        storage.write(&random_account(&User2)).await.unwrap();
+        storage
+            .delete_entities(&User2, Account::entity_type())
+            .await
+            .unwrap();
+        assert!(storage.find::<Account>(&User2).await.next().await.is_none());
+    }
+
+    async fn cleanup(storage: &impl Storage) {
+        storage.delete_user_data(&User1).await.unwrap();
+        storage.delete_user_data(&User2).await.unwrap();
+        assert!(storage.find::<Account>(&User1).await.next().await.is_none());
+        assert!(storage.find::<Account>(&User2).await.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_memory_storage() {
+        let storage = MemoryStorage::new(TABLE).await;
+        cleanup(&storage).await;
+        test_storage(&storage).await;
+        cleanup(&storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_dynamodb_storage() {
+        if std::env::var("AWS_PROFILE").is_err() && std::env::var("AWS_ACCESS_KEY_ID=").is_err() {
+            println!("No AWS credentials set, skipping DynamoDB test");
+            return;
+        }
+        let storage = DynamoStorage::new(TABLE).await;
+        cleanup(&storage).await;
+        test_storage(&storage).await;
+        cleanup(&storage).await;
+    }
+}

--- a/api/core/src/storage_dynamodb.rs
+++ b/api/core/src/storage_dynamodb.rs
@@ -1,0 +1,238 @@
+use std::{collections::HashMap, pin::Pin};
+
+use aws_config::BehaviorVersion;
+use aws_sdk_dynamodb::{
+    error::DisplayErrorContext,
+    types::{AttributeValue, DeleteRequest, Select, WriteRequest},
+    Client,
+};
+use futures::Stream;
+
+use async_stream::stream;
+
+use crate::{
+    entities::UserId,
+    storage::{Entity, Key, Storage, StorageErr},
+};
+
+// DynamoDB based storage
+pub struct DynamoStorage {
+    client: Client,
+    table: &'static str,
+}
+
+impl DynamoStorage {
+    async fn batch_delete(&self, data: Vec<(String, String)>) -> Result<(), StorageErr> {
+        self.client
+            .batch_write_item()
+            .request_items(
+                self.table,
+                data.into_iter()
+                    .map(|(pk, sk)| {
+                        WriteRequest::builder()
+                            .set_delete_request(Some(
+                                DeleteRequest::builder()
+                                    .key("pk", AttributeValue::S(pk))
+                                    .key("sk", AttributeValue::S(sk))
+                                    .build()
+                                    .expect("DeleteRequest should be always created"),
+                            ))
+                            .build()
+                    })
+                    .collect(),
+            )
+            .send()
+            .await
+            .map_err(|err| {
+                StorageErr::IOError(format!(
+                    "Failed to delete the keys: {}",
+                    DisplayErrorContext(&err)
+                ))
+            })
+            .map(|_| ())
+    }
+}
+
+impl Storage for DynamoStorage {
+    async fn new(table: &'static str) -> Self {
+        let shared_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+        let client = Client::new(&shared_config);
+        Self { client, table }
+    }
+
+    async fn write<T: Entity>(&self, entity: &T) -> Result<(), StorageErr> {
+        let pk = AttributeValue::S(entity.key().user_id.as_str().to_string());
+        let sk = sort_key(T::entity_type(), &entity.key().entity_id);
+        let builder = self
+            .client
+            .put_item()
+            .table_name(self.table)
+            .item("pk", pk)
+            .item("sk", sk);
+
+        entity
+            .serialize(builder)
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|err| {
+                StorageErr::IOError(format!(
+                    "Failed to write an entity: {}",
+                    DisplayErrorContext(&err)
+                ))
+            })
+    }
+
+    async fn read<T>(&self, key: Key) -> Result<T, StorageErr>
+    where
+        T: Entity,
+    {
+        let pk = key.user_id.as_str().to_string();
+        let sk = sort_key(T::entity_type(), key.entity_id.as_str());
+        let keys = HashMap::from([
+            ("pk".to_string(), AttributeValue::S(pk)),
+            ("sk".to_string(), sk),
+        ]);
+        let data = self
+            .client
+            .get_item()
+            .table_name(self.table)
+            .set_key(Some(keys))
+            .send()
+            .await
+            .map_err(|err| {
+                StorageErr::IOError(format!(
+                    "Failed to read an entity: {}",
+                    DisplayErrorContext(&err)
+                ))
+            })?
+            .item
+            .ok_or(StorageErr::NotFound)?;
+        T::deserialize(key, data)
+    }
+
+    async fn delete(
+        &self,
+        user_id: &UserId,
+        entity_type: Option<&str>,
+        entity_id: Option<&str>,
+    ) -> Result<usize, StorageErr> {
+        let pk = user_id.as_str().to_string();
+        // Delete a concrete entity by pk, entity name and sk
+        if let (Some(name), Some(sk)) = (entity_type, entity_id) {
+            return self
+                .batch_delete(vec![(pk, format!("{}_{}", name, sk))])
+                .await
+                .map(|_| 1);
+        }
+
+        // DynamoDB doesn't provide a simple way to delete records by partition or by sort key prefix
+        // Search those records first and then batch delete it
+        let mut attribute_values =
+            HashMap::from([(":pk".to_string(), AttributeValue::S(pk.to_string()))]);
+
+        let filter = match entity_type {
+            Some(name) => {
+                attribute_values.insert(":sk".to_string(), AttributeValue::S(format!("{}_", name)));
+                "pk = :pk AND sk > :sk"
+            }
+            None => "pk = :pk",
+        };
+
+        let mut items = self
+            .client
+            .query()
+            .table_name(self.table)
+            .key_condition_expression(filter)
+            .set_expression_attribute_values(Some(attribute_values))
+            .select(Select::SpecificAttributes)
+            .projection_expression("pk,sk")
+            .into_paginator()
+            .items()
+            .send();
+        let mut deleted = 0;
+        let mut delete_chunk = Vec::new();
+        while let Some(v) = items.next().await {
+            let data = v.map_err(|err| {
+                StorageErr::IOError(format!(
+                    "Failed to fetch keys for deletion: {}",
+                    DisplayErrorContext(&err)
+                ))
+            })?;
+
+            if delete_chunk.len() == 25 {
+                deleted += delete_chunk.len();
+                self.batch_delete(delete_chunk).await?;
+                delete_chunk = vec![];
+            }
+
+            let pk = data.get("pk").expect("pk should exists");
+            let pk = pk.as_s().expect("pk should be a string").to_owned();
+            let sk = data.get("sk").expect("sk should exists");
+            let sk = sk.as_s().expect("sk should be a string").to_owned();
+            delete_chunk.push((pk, sk))
+        }
+        if !delete_chunk.is_empty() {
+            deleted += delete_chunk.len();
+            self.batch_delete(delete_chunk).await?;
+        }
+        Ok(deleted)
+    }
+
+    async fn find<T>(&self, user_id: &UserId) -> Pin<Box<dyn Stream<Item = Result<T, StorageErr>>>>
+    where
+        T: Entity + 'static,
+    {
+        let entity_type = T::entity_type();
+        let pk = user_id.as_str().to_string();
+        let mut attributes = HashMap::new();
+        attributes.insert(":pk".to_string(), AttributeValue::S(pk));
+        attributes.insert(
+            ":sk".to_string(),
+            AttributeValue::S(format!("{}_", entity_type)),
+        );
+
+        let res = self
+            .client
+            .query()
+            .table_name(self.table)
+            .key_condition_expression("pk = :pk AND sk > :sk")
+            .set_expression_attribute_values(Some(attributes));
+        let mut paginator = res.into_paginator().items().send();
+        let stream = stream! {
+            while let Some(v) = paginator.next().await {
+                let data = v.map_err(|err| StorageErr::IOError(format!("Error streaming entity: {}", DisplayErrorContext(&err))))?;
+                let user_id = read_string_attribute("pk", &data)?;
+                let full_sk = read_string_attribute("sk", &data)?;
+                let entity_id = &full_sk[entity_type.len() + 1..]; // sort key is "[ENTITY_TYPE]_[ENTITY_ID]", remove prefix
+                let key = Key {
+                     user_id: user_id.parse().map_err(|_| StorageErr::ValidationError("Cannot create user id".to_string()))?,
+                     entity_id: entity_id.to_string(),
+                };
+                yield T::deserialize(key, data);
+            }
+        };
+        Box::pin(stream)
+    }
+}
+
+fn sort_key(entity_name: &str, sk: &str) -> AttributeValue {
+    AttributeValue::S(format!("{}_{}", entity_name, sk))
+}
+
+fn read_string_attribute(
+    key: &str,
+    data: &HashMap<String, AttributeValue>,
+) -> Result<String, StorageErr> {
+    data.get(key)
+        .ok_or(StorageErr::ValidationError(format!(
+            "{} attribute should exists",
+            key
+        )))
+        .and_then(|v| {
+            v.as_s().map_err(|_| {
+                StorageErr::ValidationError(format!("{} attribute should be of type string", key))
+            })
+        })
+        .cloned()
+}

--- a/api/core/src/storage_memory.rs
+++ b/api/core/src/storage_memory.rs
@@ -1,0 +1,124 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    pin::Pin,
+    sync::Mutex,
+};
+
+use aws_config::BehaviorVersion;
+use aws_sdk_dynamodb::{
+    operation::put_item::builders::PutItemFluentBuilder, types::AttributeValue, Client,
+};
+use futures::{stream, Stream};
+
+use crate::{
+    entities::UserId,
+    storage::{Entity, Key, Storage, StorageErr},
+};
+
+// Memory storage, used only for testing and development. In case of errors, it panics most of the time
+// to highlight mistakes early in the development process
+pub struct MemoryStorage {
+    data: Mutex<BTreeMap<String, PutItemFluentBuilder>>,
+    client: Client,
+}
+
+impl Storage for MemoryStorage {
+    async fn new(_: &'static str) -> Self {
+        let shared_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+        let client = Client::new(&shared_config);
+        Self {
+            data: Mutex::from(BTreeMap::default()),
+            client,
+        }
+    }
+
+    async fn write<T: Entity>(&self, entity: &T) -> Result<(), StorageErr> {
+        let pk = entity.key().user_id.as_str().to_string();
+        let sk = format!("{}_{}", T::entity_type(), entity.key().entity_id);
+        let storage_key = format!("{}_{}", pk, sk);
+        let mut data = self.data.lock().expect("Error locking data");
+        data.insert(
+            storage_key,
+            entity.serialize(
+                self.client
+                    .put_item()
+                    .item("pk", AttributeValue::S(pk))
+                    .item("sk", AttributeValue::S(sk)),
+            ),
+        );
+        Ok(())
+    }
+
+    async fn read<T>(&self, key: Key) -> Result<T, StorageErr>
+    where
+        T: Entity,
+    {
+        let pk = key.user_id.as_str().to_string();
+        let sk = format!("{}_{}", T::entity_type(), key.entity_id);
+        let storage_key = format!("{}_{}", pk, sk);
+        let data = self.data.lock().expect("Error locking data");
+        let item = match data.get(&storage_key) {
+            Some(item) => item,
+            None => return Err(StorageErr::NotFound),
+        };
+        let data = item.as_input().clone().build().unwrap().item.unwrap();
+        T::deserialize(key, data)
+    }
+
+    async fn delete(
+        &self,
+        user_id: &UserId,
+        entity_type: Option<&str>,
+        entity_id: Option<&str>,
+    ) -> Result<usize, StorageErr> {
+        let mut data = self.data.lock().expect("Error locking data");
+        let len_before = data.len();
+        let prefix = match (entity_type, entity_id) {
+            (None, None) => format!("{}_", user_id.as_str()),
+            (Some(entity), None) => format!("{}_{}_", user_id.as_str(), entity),
+            (Some(entity), Some(sk)) => format!("{}_{}_{}", user_id.as_str(), entity, sk),
+            (None, Some(_)) => {
+                return Err(StorageErr::ValidationError(
+                    "Cannot delete by sort key without entity name".to_string(),
+                ))
+            }
+        };
+        data.retain(|k, _| !k.starts_with(&prefix));
+        Ok(len_before - data.len())
+    }
+
+    async fn find<T>(&self, user_id: &UserId) -> Pin<Box<dyn Stream<Item = Result<T, StorageErr>>>>
+    where
+        T: Entity + 'static,
+    {
+        let entity_type = T::entity_type();
+        let prefix = format!("{}_{}", user_id.as_str(), entity_type);
+        let data = self.data.lock().expect("Error locking data");
+        let mut results = vec![];
+        for (key, value) in data.range(prefix..) {
+            if !key.starts_with(key) {
+                break;
+            }
+            let data = value.as_input().clone().build().unwrap().item.unwrap();
+            let full_sk = read_string_attribute("sk", &data);
+            let entity_id = &full_sk[entity_type.len() + 1..]; // sort key is "[ENTITY_TYPE]_[ENTITY_ID]", remove prefix
+            let key = Key {
+                user_id: read_string_attribute("pk", &data)
+                    .parse()
+                    .expect("Expected valid user_id"),
+                entity_id: entity_id.to_string(),
+            };
+            let entity = T::deserialize(key, data).expect("Deserialization should succeed");
+            results.push(Ok(entity));
+        }
+        Box::pin(stream::iter(results))
+    }
+}
+
+fn read_string_attribute(key: &str, data: &HashMap<String, AttributeValue>) -> String {
+    data.get(key)
+        .unwrap_or_else(|| panic!("{} attribute should exists", key))
+        .as_s()
+        .unwrap_or_else(|_| panic!("{} attribute should be of type string", key))
+        .clone()
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -24,3 +24,33 @@ module "api" {
   source          = "./api"
   certificate-arn = module.domain.certificate_arn
 }
+
+module "storage" {
+  source     = "./storage"
+  table-name = "game_data"
+}
+
+# Following setup is for CI and testing purposes
+
+module "storage_test" {
+  source     = "./storage"
+  table-name = "game_data_test"
+}
+
+module "user_ci" {
+  source = "./user"
+  name   = "ci"
+  iam_policies = [
+    module.storage_test.iam_reader,
+    module.storage_test.iam_writer
+  ]
+}
+
+output "user_ci_access_key" {
+  value = module.user_ci.access_key_id
+}
+
+output "user_ci_access_secret" {
+  value     = module.user_ci.access_key_secret
+  sensitive = true
+}

--- a/infra/storage/main.tf
+++ b/infra/storage/main.tf
@@ -1,0 +1,60 @@
+resource "aws_dynamodb_table" "game_data" {
+  name                        = var.table-name
+  billing_mode                = "PAY_PER_REQUEST"
+  hash_key                    = "pk"
+  range_key                   = "sk"
+  deletion_protection_enabled = true
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+}
+
+resource "aws_iam_policy" "game_data_reader" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:Query",
+          # No Scan as reading should use only Query functionality
+        ]
+        Effect   = "Allow"
+        Resource = aws_dynamodb_table.game_data.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "game_data_writer" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:BatchWriteItem",
+        ]
+        Effect   = "Allow"
+        Resource = aws_dynamodb_table.game_data.arn
+      }
+    ]
+  })
+}
+
+output "iam_reader" {
+  value = aws_iam_policy.game_data_reader.arn
+}
+
+output "iam_writer" {
+  value = aws_iam_policy.game_data_writer.arn
+}

--- a/infra/storage/variables.tf
+++ b/infra/storage/variables.tf
@@ -1,0 +1,3 @@
+variable "table-name" {
+  description = "DynamoDB table name"
+}

--- a/infra/user/main.tf
+++ b/infra/user/main.tf
@@ -1,0 +1,22 @@
+resource "aws_iam_user" "user" {
+  name = var.name
+}
+
+resource "aws_iam_user_policy_attachment" "policy_attachments" {
+  for_each   = toset(var.iam_policies)
+  user       = aws_iam_user.user.name
+  policy_arn = each.value
+}
+
+resource "aws_iam_access_key" "access_key" {
+  user = aws_iam_user.user.name
+}
+
+output "access_key_id" {
+  value = aws_iam_access_key.access_key.id
+}
+
+output "access_key_secret" {
+  value     = aws_iam_access_key.access_key.secret
+  sensitive = true
+}

--- a/infra/user/variables.tf
+++ b/infra/user/variables.tf
@@ -1,0 +1,8 @@
+variable "iam_policies" {
+  type        = list(string)
+  description = "Array of IAM policies to attach to the user"
+}
+
+variable "name" {
+  description = "Name of the user"
+}

--- a/run.sh
+++ b/run.sh
@@ -33,7 +33,7 @@ build() {
 # Run all the tests
 test() {
   log "Testing all Rust projects"
-  cargo test --release
+  cargo test --release -- --nocapture
 }
 
 # Run linters and other static checkers


### PR DESCRIPTION
- CI - Add AWS access key to be used in tests. User has only an access to test DynamoDB table
- api/core - New module which contains all the shared logic for all API modules with implemented storage (DynamoDB based and Memory one for testing) and entities with first one being `Account`
- Infrastructure for DynamoDB tables - one for prod and another one for CI. Also it handles creation of a test user which is used in CI and also handy for local development