### PR TITLE
ci Allow dependabot to run without secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         key: cargo-linux-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: cargo-linux
     - uses: aws-actions/configure-aws-credentials@v4
+      if: github.actor != 'dependabot[bot]' # Dependabot doesn't have access to secrets, skip this step
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Dependabot doesn't have access to secrets, so pull requests it creates fail. For example: https://github.com/deusvent/deusvent/pull/16

This PR modifies the CI to skip AWS credentials configuration if the PR is made by Dependabot. Tests will still run, but any tests requiring AWS credentials will be skipped.

This may create a situation where the pull request CI succeeds, but the CI build on the main branch fails because new dependency wasn't properly tested in PR. Not perfect, but should happen rather rarely. 