### PR TITLE
api/core Properly determine when AWS tests can run

### DIFF
--- a/api/core/src/storage.rs
+++ b/api/core/src/storage.rs
@@ -182,7 +182,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dynamodb_storage() {
-        if std::env::var("AWS_PROFILE").is_err() && std::env::var("CI").is_err() {
+        if std::env::var("AWS_PROFILE").is_err() && std::env::var("AWS_ACCESS_KEY_ID").is_err() {
             println!("No AWS credentials set, skipping DynamoDB test");
             return;
         }


### PR DESCRIPTION
`CI` env variable is always set, but we want DynamoDB tests to run only in case there is a valid AWS credentials and check for `AWS_ACCESS_KEY_ID` is a right one