### PR TITLE
logic Add modules for messages, time, data and game Decay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,12 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "logic"
 version = "0.0.0"
+dependencies = [
+ "messages-macro",
+ "serde",
+ "serde_json",
+ "time",
+]
 
 [[package]]
 name = "logic-binding-cpp"
@@ -1233,6 +1239,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "messages-macro"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -1425,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1802,9 +1817,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/client-unreal/deusvent/Config/DefaultGame.ini
+++ b/client-unreal/deusvent/Config/DefaultGame.ini
@@ -2,4 +2,5 @@
 [/Script/EngineSettings.GeneralProjectSettings]
 ProjectID=3274C657464BFDC2575B1CACA298B01B
 CopyrightNotice=
+ProjectVersion=0.0.1
 

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
+messages-macro = { path = "messages-macro" }
+time = "0.3.36"

--- a/logic/README.md
+++ b/logic/README.md
@@ -1,0 +1,12 @@
+# logic
+
+A core shared library used across all clients and servers. It contains shared structures and the core game logic.
+
+- We are targeting iOS, Android, Mac and Linux operating systems - ensure that all code and dependencies are compatible
+- We need to support the `amd64` and `arm64` architectures, as well as WebAssembly - check carefully your code and dependencies
+- Avoid using `usize` in public interfaces. While most targets are 64-bit, the WASM environment is still 32-bit. We will use binary encoding for data transfer/persistence and using `usize` can lead to hard-to-detect issues
+- Currently, we use JSON for serialization because the AWS API WebSocket Gateway doesn’t support binary data. In the future, we will implement a workaround, so write all messages with that in mind
+- The core logic should be free of any I/O operations, relying only on pure functions. I/O is highly platform-dependent and should be implemented elsewhere
+- The core library should not contain any logging. Logging should be handled by external code. If you need to provide additional information, consider returning types that describe the operation results instead of logging
+- As a core game library, all public interfaces must be fully documented with clear comments
+- While panics should generally be avoided, and `Result<T, E>` should be returned in most cases, using `::expect` is acceptable in scenarios where you are certain an error should never occur. It will occur eventually anyway, but hopefully we'll learn something from it

--- a/logic/messages-macro/Cargo.toml
+++ b/logic/messages-macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "messages-macro"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+proc-macro2 = "1.0.86"
+quote = "1.0.37"
+syn = "2.0.77"
+
+[lib]
+proc-macro = true

--- a/logic/messages-macro/src/lib.rs
+++ b/logic/messages-macro/src/lib.rs
@@ -1,0 +1,55 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, LitStr};
+
+// Procedural macros that creates a custom serialization logic for the given message
+// struct which automatically implement `Message` trait
+#[proc_macro_attribute]
+pub fn message(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let action_name = parse_macro_input!(attr as LitStr);
+    let input = parse_macro_input!(item as DeriveInput);
+    let struct_name = &input.ident;
+    let fields = match &input.data {
+        Data::Struct(data) => &data.fields,
+        _ => panic!("command macro only supports structs"),
+    };
+
+    let serialize_fields = fields.iter().map(|field| {
+        let name = &field.ident;
+        quote! {
+            state.serialize_field(stringify!(#name), &self.#name)?;
+        }
+    });
+
+    let fields_len = fields.len();
+
+    let expanded = quote! {
+        #[derive(serde::Deserialize, std::cmp::PartialEq, std::fmt::Debug)]
+        #input
+
+        impl crate::messages::Message for #struct_name {
+            fn action_type() -> &'static str {
+                #action_name
+            }
+
+            fn serialize(&self) -> Result<Vec<u8>, crate::messages::SerializationError> {
+                use serde::ser::{Serialize, SerializeStruct, Serializer};
+                let mut data = Vec::new();
+                let mut serializer = serde_json::Serializer::new(&mut data);
+                let mut state = serializer.serialize_struct(stringify!(#struct_name), #fields_len)?;
+                #(#serialize_fields)*
+                state.end()?;
+                Ok(data)
+            }
+
+            fn deserialize(data: &[u8]) -> Result<Self, crate::messages::SerializationError> {
+                 let parsed = serde_json::from_slice(data)?;
+                 Ok(parsed)
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/logic/src/auth.rs
+++ b/logic/src/auth.rs
@@ -1,0 +1,19 @@
+//! Shared code related to the authentication
+
+/// JWT based authentication token which is required for all player API calls
+pub struct AuthToken {
+    token: String,
+}
+
+impl AuthToken {
+    /// Serialize JWT token to string
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// Creates new auth token from the given string
+    pub fn from_string(token: String) -> Self {
+        // TODO Validate the token
+        Self { token }
+    }
+}

--- a/logic/src/date.rs
+++ b/logic/src/date.rs
@@ -1,0 +1,197 @@
+//! Date related functionality
+
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
+
+use crate::time::Duration;
+
+/// Date, format YYYY-MM-DD
+#[derive(Debug, PartialEq, Clone)]
+pub struct Date(time::Date);
+
+impl Date {
+    /// Create new date object from given parameters where month and day starts with 1
+    pub fn new(year: i32, month: u8, day: u8) -> Self {
+        let month = time::Month::try_from(month).expect("invalid month number");
+        let date = time::Date::from_calendar_date(year, month, day).expect("invalid date");
+        Date(date)
+    }
+
+    /// Returns a new `Date` that is earlier by the specified number of days
+    pub fn remove_days(&self, days: usize) -> Date {
+        let res = self.0.saturating_add(time::Duration::days(-(days as i64)));
+        Self(res)
+    }
+
+    /// Returns a new `Date` that is later by the specified number of days
+    pub fn add_days(&self, days: usize) -> Date {
+        let res = self.0.saturating_add(time::Duration::days(days as i64));
+        Self(res)
+    }
+
+    /// Returns current year
+    pub fn year(&self) -> usize {
+        self.0.year() as usize
+    }
+
+    /// Returns current month in range from 1 to 12
+    pub fn month(&self) -> usize {
+        self.0.month() as usize
+    }
+
+    /// Returns current day in range from 1 to 31
+    pub fn day(&self) -> usize {
+        self.0.day() as usize
+    }
+
+    /// Returns the zero-indexed number of days from Monday e.g. Tuesday is 1
+    pub fn days_from_monday(&self) -> u8 {
+        self.0.weekday().number_days_from_monday()
+    }
+
+    /// Returns Date of the beginning of the current week
+    pub fn as_start_of_week(&self) -> Self {
+        self.remove_days(self.days_from_monday().into())
+    }
+
+    /// Returns Date of the beginning of the current month
+    pub fn as_start_of_month(&self) -> Self {
+        self.remove_days(self.day() - 1)
+    }
+
+    /// Returns Date of the beginning of the current year
+    pub fn as_start_of_year(&self) -> Self {
+        Date::new(
+            self.year()
+                .try_into()
+                .expect("Cannot get a year from DateDay"),
+            1,
+            1,
+        )
+    }
+
+    /// Returns absolute duration difference between two dates
+    pub fn diff(&self, other: &Date) -> Duration {
+        let diff = (self.0 - other.0).whole_seconds().unsigned_abs() as u32;
+        Duration::new(diff)
+    }
+}
+
+impl Display for Date {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "{:04}-{:02}-{:02}",
+            self.0.year(),
+            self.0.month() as u8,
+            self.0.day()
+        ))
+    }
+}
+
+impl FromStr for Date {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        check_format(s, vec!['d', 'd', 'd', 'd', '-', 'd', 'd', '-', 'd', 'd'])?;
+        let year: i32 = parse_number(&s[0..4], 1900, 3000)?;
+        let month: u8 = parse_number(&s[5..7], 1, 12)?;
+        let month = time::Month::try_from(month).expect("invalid month number");
+        let day: u8 = parse_number(&s[8..10], 1, 31)?;
+        let date = time::Date::from_calendar_date(year, month, day)
+            .map_err(|err| format!("invalid date: {}", err))?;
+        Ok(Date(date))
+    }
+}
+
+fn parse_number<T: FromStr + Ord + Display>(s: &str, min: T, max: T) -> Result<T, String> {
+    let parsed = match s.parse::<T>() {
+        Ok(parsed) => parsed,
+        _ => return Err(format!("Cannot parse {}", s)),
+    };
+    if parsed < min || parsed > max {
+        return Err(format!(
+            "Value is out of range of {}..{}, got {}",
+            min, max, parsed
+        ));
+    };
+    Ok(parsed)
+}
+
+fn check_format(s: &str, format: Vec<char>) -> Result<(), String> {
+    let mut idx = 0;
+    for c in s.chars() {
+        if idx == format.len() {
+            return Err(format!(
+                "String is longer than expected length of {}",
+                format.len()
+            ));
+        }
+        let expected = format[idx];
+        if expected == 'd' && !c.is_ascii_digit() {
+            return Err(format!("Expected digit at index {}, got {}", idx, c));
+        }
+        if expected != 'd' && expected != c {
+            return Err(format!("Expected {} at index {}, got {}", expected, idx, c));
+        }
+        idx += 1;
+    }
+    if idx != format.len() {
+        return Err(format!(
+            "Expected string length of {}, got {}",
+            format.len(),
+            idx
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_format() {
+        assert_eq!(Date::new(2022, 5, 9).to_string(), "2022-05-09")
+    }
+
+    #[test]
+    fn date_day_of_week() {
+        let day = Date::new(2023, 7, 6);
+        assert_eq!(day.days_from_monday(), 3); // Thursday is 3 days from Monday
+        assert_eq!(day.remove_days(3).days_from_monday(), 0); // Finding beginning of the week - Monday
+        assert_eq!(day.add_days(3).days_from_monday(), 6); // Finding end of the week - Sunday
+    }
+
+    #[test]
+    fn date_as_start() {
+        let day = Date::new(2023, 7, 6);
+        assert_eq!(day.as_start_of_week(), Date::new(2023, 7, 3));
+        assert_eq!(day.as_start_of_month(), Date::new(2023, 7, 1));
+        assert_eq!(day.as_start_of_year(), Date::new(2023, 1, 1));
+    }
+
+    #[test]
+    fn date_parse() {
+        assert_eq!("2022-05-09".parse::<Date>().unwrap(), Date::new(2022, 5, 9));
+        assert_eq!("2022-01-01".parse::<Date>().unwrap(), Date::new(2022, 1, 1));
+        assert_eq!(
+            "2022-12-31".parse::<Date>().unwrap(),
+            Date::new(2022, 12, 31)
+        );
+        assert!("2022-13-31".parse::<Date>().is_err());
+        assert!("2022-12-32".parse::<Date>().is_err());
+        assert!("2022-00-09".parse::<Date>().is_err());
+        assert!("2022-13-09".parse::<Date>().is_err());
+        assert!("2022-09-32".parse::<Date>().is_err());
+    }
+
+    #[test]
+    fn date_diff() {
+        let d1 = Date::new(2022, 5, 9);
+        let d2 = Date::new(2022, 5, 10);
+        assert_eq!(d1.diff(&d2).whole_days(), 1);
+        assert_eq!(d2.diff(&d1).whole_days(), 1);
+    }
+}

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -1,14 +1,8 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+//! Main shared library which is used across all the clients and servers
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#![deny(missing_docs)] // Logic is a main shared library - require docs for all public interfaces
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod auth;
+pub mod date;
+pub mod messages;
+pub mod time;

--- a/logic/src/messages/auth/mod.rs
+++ b/logic/src/messages/auth/mod.rs
@@ -1,0 +1,3 @@
+//! Messages related to authentication
+
+pub mod register;

--- a/logic/src/messages/auth/register.rs
+++ b/logic/src/messages/auth/register.rs
@@ -1,0 +1,11 @@
+//! Messages related to registration
+
+use messages_macro::message;
+
+/// Automatic client registration command. Issued on a first client run to
+/// automatically create a user profile
+#[message("command.auth.register")]
+pub struct Register {
+    /// Game client version in the form of "1.0.0"
+    pub client_version: String,
+}

--- a/logic/src/messages/game/decay.rs
+++ b/logic/src/messages/game/decay.rs
@@ -1,0 +1,49 @@
+//! Messages related to game Decay
+
+use crate::date::Date;
+use messages_macro::message;
+
+/// Query for the Decay data
+#[message("query.game.decay")]
+pub struct QueryDecay {}
+
+/// Data about player Decay
+#[message("data.game.decay")]
+pub struct Decay {
+    /// Amount of days left until the Decay
+    pub days_left: u16,
+}
+
+impl Decay {
+    /// Duration of Decay in days is 10 years, plus 1 to make it a beautiful prime number
+    pub const DECAY_DURATION: u16 = 3651;
+
+    /// Returns the adjusted number of remaining decay days based on the time the decay data was fetched and the current time
+    pub fn adjusted_days_left(&self, fetched_at: &Date, today: &Date) -> u16 {
+        let diff = fetched_at.diff(today).whole_days() as u16;
+        self.days_left - diff
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decay() {
+        let decay = Decay { days_left: 1000 };
+        let fetched_at = Date::new(2000, 1, 1);
+        assert_eq!(
+            decay.adjusted_days_left(&fetched_at, &fetched_at),
+            decay.days_left
+        );
+        assert_eq!(
+            decay.adjusted_days_left(&fetched_at, &Date::new(2000, 1, 2)),
+            decay.days_left - 1,
+        );
+        assert_eq!(
+            decay.adjusted_days_left(&fetched_at, &Date::new(2000, 2, 1)),
+            decay.days_left - 31,
+        );
+    }
+}

--- a/logic/src/messages/game/mod.rs
+++ b/logic/src/messages/game/mod.rs
@@ -1,0 +1,3 @@
+//! Messages related to game
+
+pub mod decay;

--- a/logic/src/messages/mod.rs
+++ b/logic/src/messages/mod.rs
@@ -1,0 +1,59 @@
+//! Messages structs that are used for communication between client and server
+
+pub mod auth;
+pub mod game;
+
+/// Errors that may happen during data serializations
+#[derive(Debug)]
+pub enum SerializationError {
+    /// Bad data which cannot be deserialized
+    BadData(String),
+}
+
+impl From<serde_json::Error> for SerializationError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::BadData(err.to_string())
+    }
+}
+
+/// Base trait for all messages that are send between client and server
+/// For serialization we use JSON for now, but trait is written in a way
+/// to support binary protocols in the future
+pub trait Message {
+    /// Returns message type which is used for message routing
+    fn action_type() -> &'static str;
+
+    /// Serialize message to the array of bytes for sending
+    fn serialize(&self) -> Result<Vec<u8>, SerializationError>;
+
+    /// Deserialize data to the message
+    fn deserialize(data: &[u8]) -> Result<Self, SerializationError>
+    where
+        Self: Sized;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use messages_macro::message;
+
+    #[message("foo.bar")]
+    struct TestMsg {
+        foo: String,
+        bar: usize,
+    }
+
+    #[test]
+    fn message_generation_test() {
+        assert_eq!(TestMsg::action_type(), "foo.bar");
+        let msg = TestMsg {
+            foo: "foo".to_string(),
+            bar: 42,
+        };
+        let data = msg.serialize().unwrap();
+        let json = String::from_utf8(data.clone()).unwrap();
+        assert_eq!(json, r#"{"foo":"foo","bar":42}"#);
+        let got: TestMsg = TestMsg::deserialize(&data).unwrap();
+        assert_eq!(msg, got);
+    }
+}

--- a/logic/src/time.rs
+++ b/logic/src/time.rs
@@ -1,0 +1,97 @@
+//! Time related structs and functionality
+
+use serde::{Deserialize, Serialize};
+
+/// Unix timestamp with second precision
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Timestamp(u32);
+
+impl Timestamp {
+    /// Creates a new timestamp with given amount of seconds
+    pub fn new(seconds: u32) -> Self {
+        Self(seconds)
+    }
+
+    /// Returns absolute duration from the second timestamp
+    pub fn diff(&self, other: &Timestamp) -> Duration {
+        let diff = self.0.abs_diff(other.0);
+        Duration(diff)
+    }
+}
+
+/// Time duration with second precision, string representation is in [HH:MM::SS] format
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Duration(u32);
+
+impl Duration {
+    /// Create new duration from passed amount of seconds
+    pub fn new(seconds: u32) -> Self {
+        Self(seconds)
+    }
+
+    /// Number of a whole minutes in a duration
+    pub fn whole_minutes(&self) -> u32 {
+        self.0 / 60
+    }
+
+    /// Number of whole hours in a duration
+    pub fn whole_hours(&self) -> u32 {
+        self.whole_minutes() / 60
+    }
+
+    /// Number of whole 24-hours days in a duration
+    pub fn whole_days(&self) -> u32 {
+        self.whole_hours() / 24
+    }
+}
+
+impl std::fmt::Display for Duration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hours = self.whole_hours();
+        let minutes = self.whole_minutes() - hours * 60;
+        let seconds = self.0 - hours * 60 * 60 - minutes * 60;
+        f.write_fmt(format_args!("{:02}:{:02}:{:02}", hours, minutes, seconds))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_durations() {
+        // Minutes
+        assert_eq!(Duration::new(1).whole_minutes(), 0);
+        assert_eq!(Duration::new(60).whole_minutes(), 1);
+        assert_eq!(Duration::new(61).whole_minutes(), 1);
+        // Hours
+        assert_eq!(Duration::new(1).whole_hours(), 0);
+        assert_eq!(Duration::new(60 * 60).whole_hours(), 1);
+        assert_eq!(Duration::new(3 * 60 * 60 + 1).whole_hours(), 3);
+        // Days
+        assert_eq!(Duration::new(1).whole_days(), 0);
+        assert_eq!(Duration::new(24 * 60 * 60).whole_days(), 1);
+        assert_eq!(Duration::new(2 * 24 * 60 * 60 + 1).whole_days(), 2);
+        // Min/Max
+        assert_eq!(Duration::new(0).whole_days(), 0);
+        assert_eq!(Duration::new(u32::MAX).whole_days(), 49_710);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(Duration::new(0).to_string(), "00:00:00");
+        assert_eq!(Duration::new(83).to_string(), "00:01:23");
+        assert_eq!(Duration::new(5 * 60 * 60 + 83).to_string(), "05:01:23");
+        assert_eq!(Duration::new(u32::MAX).to_string(), "1193046:28:15");
+    }
+
+    #[test]
+    fn test_timestamp() {
+        assert_eq!(Timestamp::new(1).diff(&Timestamp::new(2)), Duration::new(1));
+        let t1 = Timestamp::new(0);
+        let t2 = Timestamp::new(u32::MAX);
+        // Order doesn't matter
+        assert_eq!(t1.diff(&t2), Duration::new(u32::MAX));
+        assert_eq!(t2.diff(&t1), Duration::new(u32::MAX));
+    }
+}


### PR DESCRIPTION
- `logic::time` - Time related functionality like `Timestamp` and `Duration`
- `logic::date` - Dates related functionality like `Date`
- `logic::Message` - Basic trait for all the messages flowing between client and a server. Also there is proc-macros which handles automatic serialisation code generation
- First game object - `Decay` which will be send to every client upon automatic registration