### PR TITLE
infra Add module for secrets with first JWT auth token

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -42,3 +42,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f9631ecc21d6e5cf82ef6ef8d14c39e1dfb2a52cc8f0abb684311885ffdb79a1",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.2"
+  hashes = [
+    "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
+    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
+    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
+    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
+    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
+    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
+    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
+    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
+    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
+    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
+    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+  ]
+}

--- a/infra/api/variables.tf
+++ b/infra/api/variables.tf
@@ -1,3 +1,7 @@
 variable "certificate-arn" {
   description = "ARN of a certificate to be attached to custom domain"
 }
+
+variable "jwt_auth_secret" {
+  description = "Secret which is used for creting JWT tokens for authentication"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -20,9 +20,14 @@ module "domain" {
   api-destination-hosted_zone_id = module.api.api_gateway_zone_id
 }
 
+module "secrets" {
+  source = "./secrets"
+}
+
 module "api" {
   source          = "./api"
   certificate-arn = module.domain.certificate_arn
+  jwt_auth_secret = module.secrets.jwt_auth_secret
 }
 
 module "storage" {

--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -71,6 +71,15 @@ resource "aws_lambda_function" "lambda" {
       source_code_hash # We deploy new version via CI, so it can be ignored
     ]
   }
+  environment {
+    variables = var.env_variables
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "iam_policies" {
+  for_each   = toset(var.iam_policies)
+  role       = aws_iam_role.access.name
+  policy_arn = each.value
 }
 
 resource "aws_apigatewayv2_route" "route" {

--- a/infra/modules/lambda/variables.tf
+++ b/infra/modules/lambda/variables.tf
@@ -3,7 +3,7 @@ variable "function_name" {
 }
 
 variable "route_key" {
-  description = "Route key to be used by API Gateway"
+  description = "Route key to be used by API Gateway WebSocket routing"
 }
 
 variable "gateway_id" {
@@ -11,5 +11,17 @@ variable "gateway_id" {
 }
 
 variable "gateway_execution_arn" {
-  default = "API Gateway execution arn"
+  description = "API Gateway execution arn"
+}
+
+variable "iam_policies" {
+  type        = list(string)
+  default     = []
+  description = "Array of IAM policies that will be attached to the lambda"
+}
+
+variable "env_variables" {
+  type        = map(string)
+  default     = {}
+  description = "Map of environment variables for the lambda"
 }

--- a/infra/secrets/main.tf
+++ b/infra/secrets/main.tf
@@ -1,0 +1,10 @@
+// For easier development all the secrets are managed by Terraform and then forwarded as env variables to lambdas
+// Before going to production all the keys should be re-created and migrated to AWS Secret Manager instead
+
+resource "random_password" "jwt_auth_secret" {
+  length = 64
+}
+
+output "jwt_auth_secret" {
+  value = random_password.jwt_auth_secret.result
+}


### PR DESCRIPTION
- New `secrets` module which is responsible for all the secrets. Basically Terraform will be responsible for managing secrets and then it will be exposed as env variables in lambdas. It's probably not the most secure way of dealing with secrets and in the future we should rotate all the keys and migrate it to AWS Secret Manager. For now it's a convenient and secure enough for our purposes
- Extend `modules/lambda` to support `iam_policies` and `env_variables` so that we can configure lambdas which needs those