### PR TITLE
client-unreal Rewrite Storage using SQLiteCore plugins instead of manual sqlite3 handling

### DIFF
--- a/client-unreal/deusvent/Source/deusvent/Storage.cpp
+++ b/client-unreal/deusvent/Source/deusvent/Storage.cpp
@@ -2,169 +2,189 @@
 
 #include "Async/Async.h"
 #include "Logging/StructuredLog.h"
-#include "sqlite3.h"
+#include "SQLiteDatabase.h"
 
 DEFINE_LOG_CATEGORY(LogStorage);
 
+void PrepareSQLiteStatement(FSQLiteDatabase *DB,
+                            const char *SQL,
+                            FSQLitePreparedStatement *&Statement) {
+    Statement = new FSQLitePreparedStatement();
+    auto SQLQuery = FString(UTF8_TO_TCHAR(SQL));
+    if (!Statement->Create(*DB, *SQLQuery, ESQLitePreparedStatementFlags::Persistent)) {
+        UE_LOGFMT(
+            LogStorage, Fatal, "Error preparing statement {0}: {1}", *SQL, *DB->GetLastError());
+    }
+}
+
 void UStorage::Connect(const FString &DBName) {
     auto DBPath = FPaths::Combine(FPaths::ProjectSavedDir(), DBName);
-    UE_LOGFMT(LogStorage, Display, "Connecting to path {0}", DBPath);
-    constexpr int Flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
-    if (sqlite3_open_v2(TCHAR_TO_UTF8(*DBPath), &DB, Flags, nullptr) != SQLITE_OK) {
-        const auto Error = FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get());
-        UE_LOGFMT(LogStorage, Fatal, "Error opening database at {0}: {1}", DBPath, *Error);
+    UE_LOGFMT(LogStorage, Display, "Connecting to DB: {0}", DBPath);
+    DB = new FSQLiteDatabase();
+    if (!DB->Open(*DBPath, ESQLiteDatabaseOpenMode::ReadWriteCreate)) {
+        UE_LOGFMT(
+            LogStorage, Fatal, "Error opening database at {0}: {1}", DBPath, *DB->GetLastError());
     }
-    const auto TableCreate = R"(
+    const auto CreateTableSQL = TEXT(R"(
         CREATE TABLE IF NOT EXISTS Items (
             Key TEXT PRIMARY KEY NOT NULL,
             Value TEXT NOT NULL
         );
-    )";
-    if (sqlite3_exec(DB, TableCreate, nullptr, nullptr, nullptr) != SQLITE_OK) {
-        const auto Error = FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get());
-        UE_LOGFMT(LogStorage, Fatal, "Error creating table: {0}", *Error);
+    )");
+    auto CreateTable = new FSQLitePreparedStatement();
+    if (!CreateTable->Create(*DB, CreateTableSQL)) {
+        UE_LOGFMT(LogStorage,
+                  Fatal,
+                  "Error preparing create table statement at {0}: {1}",
+                  DBPath,
+                  *DB->GetLastError());
     }
+    if (!CreateTable->Execute()) {
+        UE_LOGFMT(LogStorage,
+                  Fatal,
+                  "Error executing creating table statement {0}: {1}",
+                  DBPath,
+                  *DB->GetLastError());
+    }
+
+    // Pre-create all the statements
+    PrepareSQLiteStatement(DB, "DELETE FROM Items", StatementClear);
+    PrepareSQLiteStatement(DB, "SELECT COUNT(*) FROM Items", StatementItemCount);
+    PrepareSQLiteStatement(DB, "SELECT Value FROM Items WHERE Key = ?", StatementGetItem);
+    PrepareSQLiteStatement(
+        DB, "INSERT OR REPLACE INTO Items (Key, Value) VALUES (?, ?)", StatementSetItem);
+    PrepareSQLiteStatement(DB, "DELETE FROM Items WHERE Key = ?", StatementRemoveItem);
+    PrepareSQLiteStatement(
+        DB, "SELECT Value from Items WHERE Key LIKE ? ORDER BY Key", StatementValues);
 }
 
 void UStorage::Disconnect() {
-    if (sqlite3_close(DB) != SQLITE_OK) {
-        const auto Error = FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get());
-        UE_LOGFMT(LogStorage, Fatal, "Error closing database: {0}", *Error);
+    FScopeLock Lock(&ConnectionLock);
+    if (!DB->Close()) {
+        UE_LOGFMT(LogStorage, Fatal, "Error closing database: {0}", *DB->GetLastError());
     }
     DB = nullptr;
 }
 
-void UStorage::Clear() const {
+void UStorage::Clear() {
+    FScopeLock Lock(&ConnectionLock);
+    const auto Statement = StatementClear;
+    Statement->Reset();
     UE_LOGFMT(LogStorage, Display, "Clearing the storage");
-    const char *ClearQuery = "DELETE FROM Items;";
-    if (sqlite3_exec(DB, ClearQuery, nullptr, nullptr, nullptr) != SQLITE_OK) {
-        const auto Error = FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get());
-        UE_LOGFMT(LogStorage, Fatal, "Error clearing database: {0}", *Error);
+    if (!Statement->Execute()) {
+        UE_LOGFMT(LogStorage, Fatal, "Error clearing database: {0}", *DB->GetLastError());
     }
 }
 
-TFuture<int32> UStorage::ItemCount() const {
+TFuture<int32> UStorage::ItemCount() {
     auto Promise = MakeShared<TPromise<int32>>();
     Async(EAsyncExecution::Thread, [this, Promise]() {
+        FScopeLock Lock(&ConnectionLock);
+        const auto Statement = StatementItemCount;
+        Statement->Reset();
         int32 Count = 0;
-        sqlite3_stmt *Statement = nullptr;
-        if (sqlite3_prepare_v2(DB, "SELECT COUNT(*) FROM Items;", -1, &Statement, nullptr) ==
-                SQLITE_OK &&
-            sqlite3_step(Statement) == SQLITE_ROW) {
-            Count = sqlite3_column_int(Statement, 0);
+        if (Statement->Step() == ESQLitePreparedStatementStepResult::Row &&
+            Statement->GetColumnValueByIndex(0, Count)) {
+            // Count is set
         } else {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error counting rows: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+            UE_LOGFMT(LogStorage, Fatal, "Error getting item count: {0}", *DB->GetLastError());
         }
-        sqlite3_finalize(Statement);
         Promise->SetValue(Count);
     });
     return Promise->GetFuture();
 }
 
-TFuture<TOptional<FString>> UStorage::GetItem(const FString &Key) const {
+TFuture<TOptional<FString>> UStorage::GetItem(const FString &Key) {
     auto Promise = MakeShared<TPromise<TOptional<FString>>>();
     Async(EAsyncExecution::Thread, [this, Promise, Key]() {
-        sqlite3_stmt *Statement = nullptr;
-        if (sqlite3_prepare_v2(
-                DB, "SELECT Value FROM Items WHERE Key = ?;", -1, &Statement, nullptr) !=
-            SQLITE_OK) {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error preparing get statement: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+        FScopeLock Lock(&ConnectionLock);
+        const auto Statement = StatementGetItem;
+        Statement->Reset();
+        if (!Statement->SetBindingValueByIndex(1, Key)) {
+            UE_LOGFMT(
+                LogStorage, Fatal, "Error binding for getting item: {0}", *DB->GetLastError());
         }
-        sqlite3_bind_text(Statement, 1, TCHAR_TO_UTF8(*Key), -1, SQLITE_TRANSIENT);
-        const auto StepResult = sqlite3_step(Statement);
-        if (StepResult == SQLITE_ROW) {
-            Promise->SetValue(FString(UTF8_TO_TCHAR(sqlite3_column_text(Statement, 0))));
-        } else if (StepResult == SQLITE_DONE) {
+        const auto StepResult = Statement->Step();
+        if (StepResult == ESQLitePreparedStatementStepResult::Row) {
+            FString Value;
+            Statement->GetColumnValueByIndex(0, Value);
+            Promise->SetValue(TOptional<FString>(Value));
+        } else if (StepResult == ESQLitePreparedStatementStepResult::Done) {
             Promise->SetValue(TOptional<FString>());
         } else {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error retrieving item: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+            UE_LOGFMT(LogStorage, Fatal, "Error retrieving item: {0}", *DB->GetLastError());
+            Promise->SetValue(TOptional<FString>());
         }
-        sqlite3_finalize(Statement);
     });
     return Promise->GetFuture();
 }
 
-TFuture<void> UStorage::SetItem(const FString &Key, const FString &Value) const {
+TFuture<void> UStorage::SetItem(const FString &Key, const FString &Value) {
     UE_LOGFMT(LogStorage, Display, "Setting a value for the key {0}", Key);
     auto Promise = MakeShared<TPromise<void>>();
     Async(EAsyncExecution::Thread, [this, Promise, Key, Value]() {
-        sqlite3_stmt *Statement = nullptr;
-        if (sqlite3_prepare_v2(DB,
-                               "INSERT OR REPLACE INTO Items (Key, Value) VALUES (?, ?);",
-                               -1,
-                               &Statement,
-                               nullptr) != SQLITE_OK) {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error saving item: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+        FScopeLock Lock(&ConnectionLock);
+        const auto Statement = StatementSetItem;
+        Statement->Reset();
+        if (!Statement->SetBindingValueByIndex(1, Key) ||
+            !Statement->SetBindingValueByIndex(2, Value)) {
+            UE_LOGFMT(
+                LogStorage, Fatal, "Error binding for setting item: {0}", *DB->GetLastError());
         }
-        sqlite3_bind_text(Statement, 1, TCHAR_TO_UTF8(*Key), -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(Statement, 2, TCHAR_TO_UTF8(*Value), -1, SQLITE_TRANSIENT);
-        if (sqlite3_step(Statement) != SQLITE_DONE) {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error saving item: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+        if (Statement->Step() != ESQLitePreparedStatementStepResult::Done) {
+            UE_LOGFMT(LogStorage, Fatal, "Error saving item: {0}", *DB->GetLastError());
         }
-        sqlite3_finalize(Statement);
         Promise->SetValue();
     });
     return Promise->GetFuture();
 }
 
-TFuture<void> UStorage::RemoveItem(const FString &Key) const {
+TFuture<void> UStorage::RemoveItem(const FString &Key) {
     UE_LOGFMT(LogStorage, Display, "Removing item for the key {0}", Key);
     auto Promise = MakeShared<TPromise<void>>();
     Async(EAsyncExecution::Thread, [this, Promise, Key]() {
-        sqlite3_stmt *Statement = nullptr;
-        const char *RemoveQuery = "DELETE FROM Items WHERE Key = ?;";
-        if (sqlite3_prepare_v2(DB, RemoveQuery, -1, &Statement, nullptr) != SQLITE_OK) {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error removing item: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+        FScopeLock Lock(&ConnectionLock);
+        const auto Statement = StatementRemoveItem;
+        Statement->Reset();
+        if (!Statement->SetBindingValueByIndex(1, Key)) {
+            UE_LOGFMT(
+                LogStorage, Fatal, "Error binding for removing item: {0}", *DB->GetLastError());
         }
-        sqlite3_bind_text(Statement, 1, TCHAR_TO_UTF8(*Key), -1, SQLITE_TRANSIENT);
-        if (sqlite3_step(Statement) != SQLITE_DONE) {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error removing item: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+        if (Statement->Step() != ESQLitePreparedStatementStepResult::Done) {
+            UE_LOGFMT(LogStorage, Fatal, "Error removing item: {0}", *DB->GetLastError());
         }
-        sqlite3_finalize(Statement);
         Promise->SetValue();
     });
     return Promise->GetFuture();
 }
 
-TFuture<TArray<FString>> UStorage::Values(const FString &KeyPrefix) const {
+// TODO Probably we need to return a pair of key and a value
+// TODO It's O(n) for the memory consumption, we can use callback style instead
+TFuture<TArray<FString>> UStorage::Values(const FString &KeyPrefix) {
     auto Promise = MakeShared<TPromise<TArray<FString>>>();
     Async(EAsyncExecution::Thread, [this, Promise, KeyPrefix]() {
+        FScopeLock Lock(&ConnectionLock);
+        const auto Statement = StatementValues;
+        Statement->Reset();
         TArray<FString> Values;
-        sqlite3_stmt *Statement = nullptr;
-        const char *Query = "SELECT Value from Items WHERE Key LIKE ? ORDER BY Key;";
-        if (sqlite3_prepare_v2(DB, Query, -1, &Statement, nullptr) != SQLITE_OK) {
-            UE_LOGFMT(LogStorage,
-                      Fatal,
-                      "Error removing item: {0}",
-                      *FString(StringCast<TCHAR>(sqlite3_errmsg(DB)).Get()));
+        if (!Statement->SetBindingValueByIndex(1, KeyPrefix + TEXT("%"))) {
+            UE_LOGFMT(
+                LogStorage, Fatal, "Error binding for finding values: {0}", *DB->GetLastError());
         }
-        sqlite3_bind_text(
-            Statement, 1, TCHAR_TO_UTF8(*(KeyPrefix + TEXT("%"))), -1, SQLITE_TRANSIENT);
-        while (sqlite3_step(Statement) == SQLITE_ROW) {
-            Values.Add(FString(UTF8_TO_TCHAR(sqlite3_column_text(Statement, 0))));
+        auto Result = Statement->Execute([&Values](const FSQLitePreparedStatement &Row)
+                                             -> ESQLitePreparedStatementExecuteRowResult {
+            FString Value;
+            if (Row.GetColumnValueByIndex(0, Value)) {
+                Values.Add(Value);
+            } else {
+                return ESQLitePreparedStatementExecuteRowResult::Error;
+            }
+            return ESQLitePreparedStatementExecuteRowResult::Continue;
+        });
+        if (Result == INDEX_NONE) {
+            UE_LOGFMT(
+                LogStorage, Fatal, "Error iterating for finding values: {0}", *DB->GetLastError());
         }
-        sqlite3_finalize(Statement);
         Promise->SetValue(MoveTemp(Values));
     });
     return Promise->GetFuture();

--- a/client-unreal/deusvent/Source/deusvent/Storage.h
+++ b/client-unreal/deusvent/Source/deusvent/Storage.h
@@ -6,7 +6,7 @@
 DECLARE_LOG_CATEGORY_EXTERN(LogStorage, Log, All);
 
 /**
- * Key/Value persistent storage based on sqlite3.
+ * Key/Value persistent storage based on sqlite3, thread safe.
  *
  * UE_LOGFMT(Fatal, ...) is used for all errors that should only occur during
  * development; in runtime, it should never fail. The only error that may occur
@@ -24,27 +24,39 @@ class DEUSVENT_API UStorage : public UObject {
     void Disconnect();
 
     // Remove all the key/values from the database
-    void Clear() const;
+    void Clear();
 
     // Returns number of keys in the database
-    TFuture<int32> ItemCount() const;
+    TFuture<int32> ItemCount();
 
     // Return and optional value for the given key
-    TFuture<TOptional<FString>> GetItem(const FString &Key) const;
+    TFuture<TOptional<FString>> GetItem(const FString &Key);
 
     // Saves the value for the given key
     // HACK: TFuture<void> is inherited from TFutureBase<int>, you need
     // to use int parameter in your callback .Next([](int /*unused*/) { })
-    TFuture<void> SetItem(const FString &Key, const FString &Value) const;
+    TFuture<void> SetItem(const FString &Key, const FString &Value);
 
     // Ensures that the row with the specified key no longer exists in the
     // database
-    TFuture<void> RemoveItem(const FString &Key) const;
+    TFuture<void> RemoveItem(const FString &Key);
 
     // Returns array of values with keys that starts with the given prefix which
     // may be empty. Results are returned sorted by the key
-    TFuture<TArray<FString>> Values(const FString &KeyPrefix) const;
+    TFuture<TArray<FString>> Values(const FString &KeyPrefix);
 
   private:
-    struct sqlite3 *DB;
+    class FSQLiteDatabase *DB;
+    // We run all the queries from different threads to avoid blocking main thread
+    // But sqlite3 connections are not thread safe, this mutex ensures that and ensure
+    // database used in a serialised way
+    FCriticalSection ConnectionLock;
+
+    // All the statements created only once and then reused
+    class FSQLitePreparedStatement *StatementClear;
+    FSQLitePreparedStatement *StatementItemCount;
+    FSQLitePreparedStatement *StatementGetItem;
+    FSQLitePreparedStatement *StatementSetItem;
+    FSQLitePreparedStatement *StatementRemoveItem;
+    FSQLitePreparedStatement *StatementValues;
 };

--- a/client-unreal/deusvent/Source/deusvent/deusvent.Build.cs
+++ b/client-unreal/deusvent/Source/deusvent/deusvent.Build.cs
@@ -12,7 +12,9 @@ public class deusvent : ModuleRules
 			"CoreUObject",
 			"Engine",
 			"InputCore",
-			"EnhancedInput"
+			"EnhancedInput",
+			"SQLiteCore",
+			"SQLiteSupport",
 		});
 		PrivateDependencyModuleNames.AddRange(new[] { "CADKernel", "WebSockets" });
 
@@ -38,32 +40,6 @@ public class deusvent : ModuleRules
 		else
 		{
 			throw new System.Exception("Unsupported platform for liblogic: " + Target.Platform);
-		}
-
-		// We assume sqlite3 is available everywhere
-		// TODO Paths looks very specific to my machine, let's check if those are the same on CI once we have it
-		if (Target.Platform == UnrealTargetPlatform.IOS)
-		{
-			var SDKPath =
-				Path.Combine(
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/");
-			PublicAdditionalLibraries.Add(Path.Combine(SDKPath, "libsqlite3.tbd"));
-		}
-		else if (Target.Platform == UnrealTargetPlatform.Mac)
-		{
-			var SDKPath =
-				Path.Combine(
-					"/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/");
-			PublicAdditionalLibraries.Add(Path.Combine(SDKPath, "libsqlite3.tbd"));
-		}
-		else if (Target.Platform == UnrealTargetPlatform.Linux)
-		{
-			PublicIncludePaths.Add(Path.Combine(EngineDirectory, "Plugins/Runtime/Database/SQLiteCore/Source/SQLiteCore/Public/sqlite"));
-			PublicAdditionalLibraries.Add("/usr/lib/x86_64-linux-gnu/libsqlite3.so");
-		}
-		else
-		{
-			throw new System.Exception("Unsupported platform for sqlite3: " + Target.Platform);
 		}
 
 		// Enable testing for non production builds

--- a/client-unreal/deusvent/deusvent.uproject
+++ b/client-unreal/deusvent/deusvent.uproject
@@ -114,6 +114,14 @@
 				"Linux",
 				"Mac"
 			]
+		},
+		{
+			"Name": "SQLiteCore",
+			"Enabled": true
+		},
+		{
+			"Name": "SQLiteSupport",
+			"Enabled": true
 		}
 	]
 }

--- a/run.sh
+++ b/run.sh
@@ -49,7 +49,6 @@ build() {
         -serverconfig=Development \
         -project=$PWD/deusvent.uproject \
         -noP4 \
-        -nodebuginfo \
         -allmaps \
         -cook \
         -build \


### PR DESCRIPTION
- Building and cross-platform support is much simpler as `SQLiteCore` is a plugin of Unreal Engine itself
- API of `Storage` remained the same, only internal implementation changed
- Actually the is a difference - previously we were opening a DB with `SQLITE_OPEN_FULLMUTEX ` to share connection between different threads. With `SQLiteCore` there is no way to pass a flag to `sqlite3`, so we rely on our custom synchronisation - locking a mutex for all the DB operations
- Whole rewrite started during CI setup for testing as storage tests were constantly failing with `sqlite disk i/o error`, but only on Linux. I thought that using `SQLiteCore` would solve it which it didn't, but after some investigation the fix was found in Unreal Engine 5.5 branch (https://github.com/EpicGames/UnrealEngine/commit/1883dfbaea6157f481ee82163caa59b7db73a428). So for now tests for storage are disabled on Linux and after 5.5 release it should be resolved and would be able to remove our hack