### PR TITLE
logic Upgrade uniffi-bindgen-cpp, remove .unused hack from messages

### DIFF
--- a/api/core/src/lambda.rs
+++ b/api/core/src/lambda.rs
@@ -188,7 +188,7 @@ mod tests {
     #[tokio::test]
     async fn public_handler_success() {
         let request_id = 1;
-        let event = event_with_body(Ping { unused: false }.serialize(request_id).unwrap());
+        let event = event_with_body(Ping {}.serialize(request_id).unwrap());
         let response = process_public_event(event, &HandlerSuccess {}).await;
         assert_eq!(response, "Ping=1");
     }
@@ -196,7 +196,7 @@ mod tests {
     #[tokio::test]
     async fn public_handler_error() {
         let request_id = 1;
-        let event = event_with_body(Ping { unused: false }.serialize(request_id).unwrap());
+        let event = event_with_body(Ping {}.serialize(request_id).unwrap());
         let response = process_public_event(event, &HandlerError {}).await;
         assert_eq!(response, "-0#3x]*4qc;lAjfA_`* x$/+fV,P|OaI2nLRj1&RQ*$L^a+J");
         let error = ServerError::deserialize(&response).unwrap();
@@ -239,7 +239,7 @@ mod tests {
         let request_id = 1;
         let keys = encryption::generate_new_keys();
         let event = event_with_body(
-            DecayQuery { unused: false }
+            DecayQuery {}
                 .serialize(
                     request_id,
                     keys.public_key.as_ref().clone(),
@@ -256,7 +256,7 @@ mod tests {
         let request_id = 1;
         let keys = encryption::generate_new_keys();
         let event = event_with_body(
-            DecayQuery { unused: false }
+            DecayQuery {}
                 .serialize(
                     request_id,
                     keys.public_key.as_ref().clone(),
@@ -307,7 +307,7 @@ mod tests {
         let keys1 = encryption::generate_new_keys();
         let keys2 = encryption::generate_new_keys();
         let event = event_with_body(
-            DecayQuery { unused: false }
+            DecayQuery {}
                 .serialize(
                     request_id,
                     keys1.public_key.as_ref().clone(),

--- a/api/lambda-common-ping/src/main.rs
+++ b/api/lambda-common-ping/src/main.rs
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn process_message_ok() {
         let now = ServerTimestamp::from_milliseconds_pure(1726219252123);
-        let response = process_message(Ping { unused: false }, 0, now.clone()).unwrap();
+        let response = process_message(Ping {}, 0, now.clone()).unwrap();
         assert_eq!(response, "-.'r4aJ:tuv)|T{7");
         let (data, req_id) = ServerStatus::deserialize(&response).unwrap();
         assert_eq!(*data.timestamp, now);

--- a/api/lambda-game-decay/src/main.rs
+++ b/api/lambda-game-decay/src/main.rs
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn process_message_ok() {
-        let msg = DecayQuery { unused: false };
+        let msg = DecayQuery {};
         let now = ServerTimestamp::from_milliseconds_pure(10);
         let response = process_message(msg, 1, now.clone()).unwrap();
         assert_eq!(response, "-/<whrHUB6=QUX@");

--- a/client-unreal/deusvent/Source/deusvent/Connection.cpp
+++ b/client-unreal/deusvent/Source/deusvent/Connection.cpp
@@ -115,7 +115,7 @@ void UConnection::SendPing() {
 // Testing sending signed authenticated message
 void UConnection::SendDecayQuery() {
     auto Keys = logic::generate_new_keys();
-    auto Msg = logic::DecayQuery{.unused = false};
+    auto Msg = logic::DecayQuery{};
     auto Serializer = logic::DecayQuerySerializer::init(Msg, Keys.public_key);
     auto Data = FString(Serializer->serialize(this->RequestId++, Keys.private_key).c_str());
     UE_LOGFMT(LogConnection, Display, "Sending Query Data: {0}", Data);

--- a/client-unreal/deusvent/Source/deusvent/logic/logic.cpp
+++ b/client-unreal/deusvent/Source/deusvent/logic/logic.cpp
@@ -1286,6 +1286,7 @@ void FfiConverterTypeDecay::write(RustStream &stream, const Decay &val) {
 }
 
 int32_t FfiConverterTypeDecay::allocation_size(const Decay &val) {
+
     return FfiConverterServerTimestamp::allocation_size(val.started_at) +
            FfiConverterDuration::allocation_size(val.length);
 }
@@ -1309,15 +1310,15 @@ RustBuffer FfiConverterTypeDecayQuery::lower(const DecayQuery &val) {
 }
 
 DecayQuery FfiConverterTypeDecayQuery::read(RustStream &stream) {
-    return {FfiConverterBool::read(stream)};
+    return {};
 }
 
 void FfiConverterTypeDecayQuery::write(RustStream &stream, const DecayQuery &val) {
-    FfiConverterBool::write(stream, val.unused);
 }
 
 int32_t FfiConverterTypeDecayQuery::allocation_size(const DecayQuery &val) {
-    return FfiConverterBool::allocation_size(val.unused);
+
+    return 0;
 }
 
 Identity FfiConverterTypeIdentity::lift(RustBuffer buf) {
@@ -1347,6 +1348,7 @@ void FfiConverterTypeIdentity::write(RustStream &stream, const Identity &val) {
 }
 
 int32_t FfiConverterTypeIdentity::allocation_size(const Identity &val) {
+
     return FfiConverterTypeSafeString::allocation_size(val.name);
 }
 
@@ -1378,6 +1380,7 @@ void FfiConverterTypeKeys::write(RustStream &stream, const Keys &val) {
 }
 
 int32_t FfiConverterTypeKeys::allocation_size(const Keys &val) {
+
     return FfiConverterPublicKey::allocation_size(val.public_key) +
            FfiConverterPrivateKey::allocation_size(val.private_key);
 }
@@ -1401,15 +1404,15 @@ RustBuffer FfiConverterTypePing::lower(const Ping &val) {
 }
 
 Ping FfiConverterTypePing::read(RustStream &stream) {
-    return {FfiConverterBool::read(stream)};
+    return {};
 }
 
 void FfiConverterTypePing::write(RustStream &stream, const Ping &val) {
-    FfiConverterBool::write(stream, val.unused);
 }
 
 int32_t FfiConverterTypePing::allocation_size(const Ping &val) {
-    return FfiConverterBool::allocation_size(val.unused);
+
+    return 0;
 }
 
 ServerError FfiConverterTypeServerError::lift(RustBuffer buf) {
@@ -1449,6 +1452,7 @@ void FfiConverterTypeServerError::write(RustStream &stream, const ServerError &v
 }
 
 int32_t FfiConverterTypeServerError::allocation_size(const ServerError &val) {
+
     return FfiConverterTypeErrorCode::allocation_size(val.error_code) +
            FfiConverterString::allocation_size(val.error_description) +
            FfiConverterOptionalString::allocation_size(val.error_context) +
@@ -1485,6 +1489,7 @@ void FfiConverterTypeServerStatus::write(RustStream &stream, const ServerStatus 
 }
 
 int32_t FfiConverterTypeServerStatus::allocation_size(const ServerStatus &val) {
+
     return FfiConverterServerTimestamp::allocation_size(val.timestamp) +
            FfiConverterTypeStatus::allocation_size(val.status);
 }

--- a/client-unreal/deusvent/Source/deusvent/logic/logic.hpp
+++ b/client-unreal/deusvent/Source/deusvent/logic/logic.hpp
@@ -30,77 +30,19 @@ struct ServerErrorSerializer;
 struct ServerStatusSerializer;
 struct ServerTimestamp;
 struct SyncedTimestamp;
-struct Timestamp; 
-struct Decay; 
-struct DecayQuery; 
-struct Identity; 
-struct Keys; 
-struct Ping; 
-struct ServerError; 
+struct Timestamp;
+struct Decay;
+struct DecayQuery;
+struct Identity;
+struct Keys;
+struct Ping;
+struct ServerError;
 struct ServerStatus;
 struct EncryptionError;
 enum class ErrorCode;
+struct SafeString;
 struct SerializationError;
 enum class Status;
-
-namespace uniffi {
-    struct FfiConverterServerTimestamp;
-} // namespace uniffi
-
-struct ServerTimestamp {
-    friend uniffi::FfiConverterServerTimestamp;
-
-    ServerTimestamp() = delete;
-
-    ServerTimestamp(const ServerTimestamp &) = delete;
-    ServerTimestamp(ServerTimestamp &&) = delete;
-
-    ServerTimestamp &operator=(const ServerTimestamp &) = delete;
-    ServerTimestamp &operator=(ServerTimestamp &&) = delete;
-
-    ~ServerTimestamp();
-    static std::shared_ptr<ServerTimestamp> from_milliseconds(uint64_t milliseconds);
-    std::string as_string();
-
-private:
-    ServerTimestamp(void *);
-
-    void *instance;
-};
-
-namespace uniffi {
-    struct FfiConverterPrivateKey;
-} // namespace uniffi
-
-struct PrivateKey {
-    friend uniffi::FfiConverterPrivateKey;
-
-    PrivateKey() = delete;
-
-    PrivateKey(const PrivateKey &) = delete;
-    PrivateKey(PrivateKey &&) = delete;
-
-    PrivateKey &operator=(const PrivateKey &) = delete;
-    PrivateKey &operator=(PrivateKey &&) = delete;
-
-    ~PrivateKey();
-    static std::shared_ptr<PrivateKey> deserialize(const std::vector<uint8_t> &data);
-    std::vector<uint8_t> serialize();
-
-private:
-    PrivateKey(void *);
-
-    void *instance;
-};
-
-
-enum class ErrorCode: int32_t {
-    kAuthenticationError = 1,
-    kSerializationError = 2,
-    kInvalidData = 3,
-    kIoError = 4,
-    kServerError = 5
-};
 
 namespace uniffi {
     struct FfiConverterDuration;
@@ -125,6 +67,40 @@ struct Duration {
 
 private:
     Duration(void *);
+
+    void *instance;
+};
+
+
+enum class ErrorCode: int32_t {
+    kAuthenticationError = 1,
+    kSerializationError = 2,
+    kInvalidData = 3,
+    kIoError = 4,
+    kServerError = 5
+};
+
+namespace uniffi {
+    struct FfiConverterPrivateKey;
+} // namespace uniffi
+
+struct PrivateKey {
+    friend uniffi::FfiConverterPrivateKey;
+
+    PrivateKey() = delete;
+
+    PrivateKey(const PrivateKey &) = delete;
+    PrivateKey(PrivateKey &&) = delete;
+
+    PrivateKey &operator=(const PrivateKey &) = delete;
+    PrivateKey &operator=(PrivateKey &&) = delete;
+
+    ~PrivateKey();
+    static std::shared_ptr<PrivateKey> deserialize(const std::vector<uint8_t> &data);
+    std::vector<uint8_t> serialize();
+
+private:
+    PrivateKey(void *);
 
     void *instance;
 };
@@ -185,6 +161,31 @@ private:
     void *instance;
 };
 
+namespace uniffi {
+    struct FfiConverterServerTimestamp;
+} // namespace uniffi
+
+struct ServerTimestamp {
+    friend uniffi::FfiConverterServerTimestamp;
+
+    ServerTimestamp() = delete;
+
+    ServerTimestamp(const ServerTimestamp &) = delete;
+    ServerTimestamp(ServerTimestamp &&) = delete;
+
+    ServerTimestamp &operator=(const ServerTimestamp &) = delete;
+    ServerTimestamp &operator=(ServerTimestamp &&) = delete;
+
+    ~ServerTimestamp();
+    static std::shared_ptr<ServerTimestamp> from_milliseconds(uint64_t milliseconds);
+    std::string as_string();
+
+private:
+    ServerTimestamp(void *);
+
+    void *instance;
+};
+
 
 struct Decay {
     std::shared_ptr<ServerTimestamp> started_at;
@@ -199,12 +200,6 @@ struct ServerError {
     uint8_t request_id;
     uint16_t message_tag;
     bool recoverable;
-};
-
-
-struct ServerStatus {
-    std::shared_ptr<ServerTimestamp> timestamp;
-    Status status;
 };
 
 namespace uniffi {
@@ -246,6 +241,12 @@ private:
     std::variant<kEncrypted, kPlaintext> variant;
 
     SafeString();
+};
+
+
+struct ServerStatus {
+    std::shared_ptr<ServerTimestamp> timestamp;
+    Status status;
 };
 
 
@@ -508,12 +509,10 @@ private:
 
 
 struct DecayQuery {
-    bool unused;
 };
 
 
 struct Ping {
-    bool unused;
 };
 
 namespace uniffi {

--- a/logic/src/messages/common/ping.rs
+++ b/logic/src/messages/common/ping.rs
@@ -28,8 +28,4 @@ pub struct ServerStatus {
 
 /// Client ping message
 #[client_public_message(1)]
-pub struct Ping {
-    // HACK https://github.com/NordSecurity/uniffi-bindgen-cpp/issues/45
-    /// Unused
-    pub unused: bool,
-}
+pub struct Ping {}

--- a/logic/src/messages/game/decay.rs
+++ b/logic/src/messages/game/decay.rs
@@ -17,7 +17,4 @@ pub struct Decay {
 }
 
 #[client_player_message(2)]
-pub struct DecayQuery {
-    /// Unused
-    pub unused: bool,
-}
+pub struct DecayQuery {}

--- a/run.sh
+++ b/run.sh
@@ -30,7 +30,7 @@ deps() {
                     aarch64-apple-darwin \
                     aarch64-linux-android
   cargo fetch
-  cargo install uniffi-bindgen-cpp --git https://github.com/NordSecurity/uniffi-bindgen-cpp --tag v0.6.2+v0.25.0
+  cargo install uniffi-bindgen-cpp --git https://github.com/NordSecurity/uniffi-bindgen-cpp --tag v0.6.3+v0.25.0
 }
 
 # Builds everything, pass "client-unreal" to build the client or keep empty to test everything else


### PR DESCRIPTION
- Upgrade uniff-bindgen-cpp to the latest version to fix https://github.com/NordSecurity/uniffi-bindgen-cpp/issues/45
- Remove `unused` property from `Ping` and `DecayQuery` as this workaround is not needed anymore